### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ If you are using Swift 1.2, refer to [CheckoutKit 1.0.0](https://github.com/CKOT
 
 ### How to use the library
 
-__Cocoapods__
+__CocoaPods__
 
-The framework is available on Cocoapods. The following needs to be added in the ```Podfile```:
+The framework is available on CocoaPods. The following needs to be added in the ```Podfile```:
 ```
 use_frameworks!
 pod 'CheckoutKit', '~>2.0.0'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
