### PR TITLE
Add .podspec to local project

### DIFF
--- a/CheckoutKit.podspec
+++ b/CheckoutKit.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name = 'CheckoutKit'
+  s.version = '3.0.3'
+  s.license = 'MIT'
+  s.summary = 'iOS version of Checkout Kit that implements Card Tokenisation'
+  s.homepage = 'https://checkout.com'
+  s.authors = { 'Checkout.com Integration": "integration@checkout.com' }
+  s.source = { :git => 'https://github.com/checkout/checkoutkit-ios.git' }
+
+  s.ios.deployment_target = '8.0'
+  
+  s.source_files = 'CheckoutKit/**/*.{swift,h,m}'
+  s.exclude_files = 'CheckoutKit/CheckoutKitTests/**'
+end

--- a/CheckoutKit.podspec
+++ b/CheckoutKit.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.license = 'MIT'
   s.summary = 'iOS version of Checkout Kit that implements Card Tokenisation'
   s.homepage = 'https://checkout.com'
-  s.authors = { 'Checkout.com Integration": "integration@checkout.com' }
+  s.authors = { 'Checkout.com Integration': 'integration@checkout.com' }
   s.source = { :git => 'https://github.com/elvi117/checkoutkit-ios', :branch => 'master' }
 
   s.ios.deployment_target = '8.0'

--- a/CheckoutKit.podspec
+++ b/CheckoutKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary = 'iOS version of Checkout Kit that implements Card Tokenisation'
   s.homepage = 'https://checkout.com'
   s.authors = { 'Checkout.com Integration': 'integration@checkout.com' }
-  s.source = { :git => 'https://github.com/elvi117/checkoutkit-ios', :branch => 'master' }
+  s.source = { :git => 'https://github.com/checkout/checkoutkit-ios', :branch => 'master' }
 
   s.ios.deployment_target = '8.0'
   

--- a/CheckoutKit.podspec
+++ b/CheckoutKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary = 'iOS version of Checkout Kit that implements Card Tokenisation'
   s.homepage = 'https://checkout.com'
   s.authors = { 'Checkout.com Integration": "integration@checkout.com' }
-  s.source = { :git => 'https://github.com/checkout/checkoutkit-ios.git' }
+  s.source = { :git => 'https://github.com/elvi117/checkoutkit-ios', :branch => 'master' }
 
   s.ios.deployment_target = '8.0'
   


### PR DESCRIPTION
When you provide podspec file inside project users can create their own additional features and directly download their changes via cocoa pods by `pod 'CheckoutKit', git: 'https://github.com/checkout/checkoutkit-ios', branch: 'anyone_available_branch'` 